### PR TITLE
wait for tcp port instead of log

### DIFF
--- a/integration-tests/integration-tests-chassis/pom.xml
+++ b/integration-tests/integration-tests-chassis/pom.xml
@@ -74,7 +74,11 @@
                                             <link>service-center:sc.servicecomb.io</link>
                                         </links>
                                         <wait>
-                                            <log>Tomcat started on port</log>
+                                            <tcp>
+                                                <ports>
+                                                    <port>8080</port>
+                                                </ports>
+                                            </tcp>
                                             <time>100000</time>
                                         </wait>
                                         <ports>
@@ -105,7 +109,11 @@
                                             <link>service-center:sc.servicecomb.io</link>
                                         </links>
                                         <wait>
-                                            <log>Tomcat started on port</log>
+                                            <tcp>
+                                                <ports>
+                                                    <port>8080</port>
+                                                </ports>
+                                            </tcp>
                                             <time>100000</time>
                                         </wait>
                                         <ports>
@@ -130,7 +138,11 @@
                                             <link>service-center:sc.servicecomb.io</link>
                                         </links>
                                         <wait>
-                                            <log>Catalina.start Server startup in</log>
+                                            <tcp>
+                                                <ports>
+                                                    <port>8080</port>
+                                                </ports>
+                                            </tcp>
                                             <time>100000</time>
                                         </wait>
                                         <ports>

--- a/integration-tests/integration-tests-spring/pom.xml
+++ b/integration-tests/integration-tests-spring/pom.xml
@@ -67,7 +67,11 @@
                                             <link>acmeair-consul:consul.acmeair.com</link>
                                         </links>
                                         <wait>
-                                            <log>Tomcat started on port</log>
+                                            <tcp>
+                                                <ports>
+                                                    <port>8080</port>
+                                                </ports>
+                                            </tcp>
                                             <time>100000</time>
                                         </wait>
                                         <ports>
@@ -95,7 +99,11 @@
                                             <link>acmeair-consul:consul.acmeair.com</link>
                                         </links>
                                         <wait>
-                                            <log>Tomcat started on port</log>
+                                            <tcp>
+                                                <ports>
+                                                    <port>8080</port>
+                                                </ports>
+                                            </tcp>
                                             <time>100000</time>
                                         </wait>
                                         <ports>
@@ -119,7 +127,11 @@
                                             <link>acmeair-consul:consul.acmeair.com</link>
                                         </links>
                                         <wait>
-                                            <log>Tomcat started on port</log>
+                                            <tcp>
+                                                <ports>
+                                                    <port>8080</port>
+                                                </ports>
+                                            </tcp>
                                             <time>100000</time>
                                         </wait>
                                         <ports>


### PR DESCRIPTION
As a bug of docker-maven-plugin, wait for the specified content output in log may occasionally fail. Because our http services listen on port 8080, we could monitor tcp port 8080  instead.